### PR TITLE
build(pr-preview): remove GA tracking id from previews

### DIFF
--- a/docusaurus.config.ci.js
+++ b/docusaurus.config.ci.js
@@ -1,6 +1,9 @@
 import config from './docusaurus.config.js';
 import headerItems from './src/config/header.navitems.js';
 
+// Remove the Google Analytics tracking ID from the PR preview
+delete config.presets[0][1].gtag
+
 /** @type {import('@docusaurus/types').Config} */
 const prConfig = {
   ...config,


### PR DESCRIPTION
Removing the google analytics tracking support from PR previews. 