### PR TITLE
fix(docs): change href for tracking consent link

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -6,7 +6,7 @@
     "message": "Getting started"
   },
   "header.actions.free_demo": {
-    "message": "Start free demo"
+    "message": "Try for free"
   },
   "header.docs": {
     "message": "Docs"
@@ -518,5 +518,5 @@
   },
   "quickstarts.teradata_university": {
     "message": "Teradata University"
-  }  
+  }
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -6,7 +6,7 @@
     "message": "Getting started"
   },
   "header.actions.free_demo": {
-    "message": "Start free demo"
+    "message": "Try for free"
   },
   "header.docs": {
     "message": "Docs"
@@ -536,5 +536,5 @@
   },
   "quickstarts.teradata_university": {
     "message": " Teradata University"
-  }  
+  }
 }

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -6,7 +6,7 @@
     "message": "Empezar"
   },
   "header.actions.free_demo": {
-    "message": "Empieza gratis"
+    "message": "Prueba gratis"
   },
   "header.docs": {
     "message": "Docs"
@@ -518,5 +518,5 @@
   },
   "quickstarts.teradata_university": {
     "message": "Teradata University"
-  }  
+  }
 }

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -6,7 +6,7 @@
     "message": "Getting started"
   },
   "header.actions.free_demo": {
-    "message": "Start free demo"
+    "message": "Try for free"
   },
   "header.docs": {
     "message": "Docs"
@@ -518,5 +518,5 @@
   },
   "quickstarts.teradata_university": {
     "message": "Teradata University"
-  }  
+  }
 }

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -6,7 +6,7 @@
     "message": "スタートガイド"
   },
   "header.actions.free_demo": {
-    "message": "無料デモを始める"
+    "message": "無料で試す"
   },
   "header.docs": {
     "message": "ドキュメント"
@@ -290,7 +290,7 @@
   "developer_home_page.tagline": {
     "message": "Your go-to hub for quickstarts, guides, tutorials, code samples, technical documentation, and downloads for all Teradata products."
   },
-   "developers.title_description": {
+  "developers.title_description": {
     "message": "すべての Teradata 製品のクイックスタート、ガイド、チュートリアル、コード サンプル、技術ドキュメント、ダウンロードのハブです。"
   },
   "developers.welcome_message": {
@@ -517,5 +517,5 @@
   },
   "quickstarts.teradata_university": {
     "message": "Teradata University"
-  }  
+  }
 }

--- a/i18n/ko/code.json
+++ b/i18n/ko/code.json
@@ -6,7 +6,7 @@
     "message": "Getting started"
   },
   "header.actions.free_demo": {
-    "message": "Start free demo"
+    "message": "Try for free"
   },
   "header.docs": {
     "message": "Docs"
@@ -518,5 +518,5 @@
   },
   "quickstarts.teradata_university": {
     "message": "Teradata University"
-  }  
+  }
 }

--- a/src/config/footer.navItems.js
+++ b/src/config/footer.navItems.js
@@ -234,7 +234,7 @@ export default function footerItems(currentLocale = 'en') {
       },
       {
         label: 'footer.tracking_consent',
-        href: `https://${footerBaseUrl}/how-we-help#tracking-consent`,
+        href: `https://${footerBaseUrl}/#tracking-consent`,
       },
     ],
     linksOfInterest: {

--- a/src/config/footer.navItems.js
+++ b/src/config/footer.navItems.js
@@ -234,7 +234,7 @@ export default function footerItems(currentLocale = 'en') {
       },
       {
         label: 'footer.tracking_consent',
-        href: `https://${footerBaseUrl}/#tracking-consent`,
+        href: `#tracking-consent`,
       },
     ],
     linksOfInterest: {


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
- Fix tracking consent issue in the footer
- Update `Start free demo` CTA text to 'Try for free`

### What's included?

<!-- List features included in this PR -->

- Change href for Tracking consent in the footer
- Change `Start free demo` text to `Try for free` wherever applicable

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1328" alt="Screenshot 2024-08-27 at 1 35 17 PM" src="https://github.com/user-attachments/assets/cc4cffdb-59e2-4f08-b4b3-e009cc91aa4d">
<img width="1722" alt="Screenshot 2024-08-27 at 3 00 10 PM" src="https://github.com/user-attachments/assets/88d691bc-c397-4c35-bd18-ee4ed74bdd5e">

<img width="1722" alt="Screenshot 2024-08-27 at 3 01 06 PM" src="https://github.com/user-attachments/assets/e9773232-48d5-477e-9297-6a07c124a5f9">

