### PR TITLE
update to be using title case

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -286,7 +286,7 @@
     "message": "The title for the sidebar in mobile view"
   },
   "developer_home_page.title": {
-    "message": "Teradata developers portal"
+    "message": "Teradata Developers Portal"
   },
   "developer_home_page.tagline": {
     "message": "Your go-to hub for quickstarts, guides, tutorials, code samples, technical documentation, and downloads for all Teradata products."

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -286,7 +286,7 @@
     "message": "The title for the sidebar in mobile view"
   },
   "developer_home_page.title": {
-    "message": "Teradata developers portal"
+    "message": "Teradata Developers Portal"
   },
   "developer_home_page.tagline": {
     "message": "Your go-to hub for quickstarts, guides, tutorials, code samples, technical documentation, and downloads for all Teradata products."

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -286,7 +286,7 @@
     "message": "The title for the sidebar in mobile view"
   },
   "developer_home_page.title": {
-    "message": "Teradata developers portal"
+    "message": "Teradata Developers Portal"
   },
   "developer_home_page.tagline": {
     "message": "Tu portal principal para guías rápidas, tutoriales, ejemplos de código, documentación técnica y descargas de todos los productos de Teradata."

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -286,7 +286,7 @@
     "message": "The title for the sidebar in mobile view"
   },
   "developer_home_page.title": {
-    "message": "Teradata developers portal"
+    "message": "Teradata Developers Portal"
   },
   "developer_home_page.tagline": {
     "message": "Your go-to hub for quickstarts, guides, tutorials, code samples, technical documentation, and downloads for all Teradata products."

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -285,7 +285,7 @@
     "message": "モバイルビューのサイドバーのタイトル"
   },
   "developer_home_page.title": {
-    "message": "Teradata developers portal"
+    "message": "Teradata Developers Portal"
   },
   "developer_home_page.tagline": {
     "message": "Your go-to hub for quickstarts, guides, tutorials, code samples, technical documentation, and downloads for all Teradata products."

--- a/i18n/ko/code.json
+++ b/i18n/ko/code.json
@@ -286,7 +286,7 @@
     "message": "The title for the sidebar in mobile view"
   },
   "developer_home_page.title": {
-    "message": "Teradata developers portal"
+    "message": "Teradata Developers Portal"
   },
   "developer_home_page.tagline": {
     "message": "Your go-to hub for quickstarts, guides, tutorials, code samples, technical documentation, and downloads for all Teradata products."


### PR DESCRIPTION
Update to be using title case. 

Currently the tab shows “Teradata developers portal”

Desired format: “Teradata Developers Portal”