### PR TITLE
docs(header): add support for spanish in language switcher

### DIFF
--- a/src/config/footer.navItems.js
+++ b/src/config/footer.navItems.js
@@ -9,11 +9,12 @@ export default function footerItems(currentLocale = 'en') {
   // Korean locale is a special case where the local is prepended to the url
   const isSpecialLocale = currentLocale === 'ko';
 
-  const footerBaseUrl = ['en', 'es'].includes(currentLocale)
-    ? 'www.teradata.com'
-    : isSpecialLocale
-    ? `${footerLocale}.teradata.com`
-    : `www.teradata.${footerLocale}`;
+  const footerBaseUrl =
+    currentLocale === 'en' || currentLocale === 'es'
+      ? 'www.teradata.com'
+      : isSpecialLocale
+      ? `${footerLocale}.teradata.com`
+      : `www.teradata.${footerLocale}`;
 
   return {
     links: [

--- a/src/config/footer.navItems.js
+++ b/src/config/footer.navItems.js
@@ -9,12 +9,11 @@ export default function footerItems(currentLocale = 'en') {
   // Korean locale is a special case where the local is prepended to the url
   const isSpecialLocale = currentLocale === 'ko';
 
-  const footerBaseUrl =
-    currentLocale === 'en'
-      ? 'www.teradata.com'
-      : isSpecialLocale
-      ? `${footerLocale}.teradata.com`
-      : `www.teradata.${footerLocale}`;
+  const footerBaseUrl = ['en', 'es'].includes(currentLocale)
+    ? 'www.teradata.com'
+    : isSpecialLocale
+    ? `${footerLocale}.teradata.com`
+    : `www.teradata.${footerLocale}`;
 
   return {
     links: [

--- a/src/config/header.navitems.js
+++ b/src/config/header.navitems.js
@@ -63,6 +63,7 @@ export default function headerItems(baseUrl = '/', currentLocale = 'en') {
         label: 'Deutschland',
         value: 'de',
       },
+      { label: 'Español', value: 'es' },
       {
         label: 'France',
         value: 'fr',


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue or feature request that is addressed by this PR. Provide context and motivation for the change. -->
Add support for choosing Spanish language in the header.

### What's included?

<!-- List features included in this PR -->

- Add `Español` option to the language switcher in the header.
- www.teradata.com does not support Spanish so the links in footer will use www.teradata.com (English) as the base url. 

#### General Tests for Every PR

Please make sure your PR adheres to the following requirements:

- [x] `npm run start` still works.
- [x] `npm run build` still works.
- [x] Code adheres to project style guidelines (e.g., linting, formatting).
- [x] Any new dependencies have been added to the appropriate files.
- [x] The changes do not introduce new issues or regressions.

### Screenshots or Visual Updates (if applicable)

<!-- If your PR includes changes to the UI or documentation that would benefit from visuals, please include screenshots or relevant images. -->
<img width="1715" alt="Screenshot 2024-09-25 at 11 37 16 AM" src="https://github.com/user-attachments/assets/634b22d2-e196-41db-893d-648835e1b766">

