### PR TITLE
Fix/ai unlimited docs title

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -278,6 +278,9 @@
   "home_page.title": {
     "message": "Teradata AI Unlimited-Dokumentation"
   },
+  "home_page.ai_unlimited.title": {
+    "message": "AI Unlimited Documentation | Teradata Developers Portal"
+  },
   "sidenav.title": {
     "message": "Dokumentation"
   },

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -279,6 +279,9 @@
   "home_page.title": {
     "message": "Teradata AI Unlimited Documentation"
   },
+  "home_page.ai_unlimited.title": {
+    "message": "AI Unlimited Documentation | Teradata Developers Portal"
+  },
   "sidenav.title": {
     "message": "Docs"
   },

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -278,6 +278,9 @@
   "home_page.title": {
     "message": "Documentación de Teradata AI Unlimited"
   },
+  "home_page.ai_unlimited.title": {
+    "message": "AI Unlimited Documentation | Teradata Developers Portal"
+  },
   "sidenav.title": {
     "message": "Documentos"
   },

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -278,6 +278,9 @@
   "home_page.title": {
     "message": "Documentation sur Teradata AI Unlimited"
   },
+  "home_page.ai_unlimited.title": {
+    "message": "AI Unlimited Documentation | Teradata Developers Portal"
+  },
   "sidenav.title": {
     "message": "Documents"
   },

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -278,6 +278,9 @@
   "home_page.title": {
     "message": "Teradata AI Unlimited ドキュメント"
   },
+  "home_page.ai_unlimited.title": {
+    "message": "AI Unlimited Documentation | Teradata Developers Portal"
+  },
   "sidenav.title": {
     "message": "ドキュメント"
   },

--- a/i18n/ko/code.json
+++ b/i18n/ko/code.json
@@ -278,6 +278,9 @@
   "home_page.title": {
     "message": "Teradata AI Unlimited 설명서"
   },
+  "home_page.ai_unlimited.title": {
+    "message": "AI Unlimited Documentation | Teradata Developers Portal"
+  },
   "sidenav.title": {
     "message": "문서"
   },

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -119,17 +119,15 @@ function Feature({ title, description, href }) {
 
 export default function HomepageFeatures() {
   return (
-    <>
-      <section className={styles.features}>
-        <div className={clsx('container', styles.container)}>
-          <h2>{translate({ message: FeatureTitle })}</h2>
-          <div className={clsx('row', styles.row)}>
-            {FeatureList.map((props, idx) => (
-              <Feature key={idx} {...props} />
-            ))}
-          </div>
+    <section className={styles.features}>
+      <div className={clsx('container', styles.container)}>
+        <h2>{translate({ message: FeatureTitle })}</h2>
+        <div className={clsx('row', styles.row)}>
+          {FeatureList.map((props, idx) => (
+            <Feature key={idx} {...props} />
+          ))}
         </div>
-      </section>
-    </>
+      </div>
+    </section>
   );
 }

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -120,7 +120,6 @@ function Feature({ title, description, href }) {
 export default function HomepageFeatures() {
   return (
     <>
-      <PossibleBanner />
       <section className={styles.features}>
         <div className={clsx('container', styles.container)}>
           <h2>{translate({ message: FeatureTitle })}</h2>

--- a/src/pages/ai-unlimited.js
+++ b/src/pages/ai-unlimited.js
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
+import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import HeroImageUrl from '@site/static/img/hero.webp';
@@ -45,6 +46,13 @@ function HomepageHeader() {
 export default function Home() {
   return (
     <Layout description={translate({ message: 'home_page.tagline' })}>
+      <Head>
+        <title>{translate({ message: 'home_page.ai_unlimited.title' })}</title>
+        <meta
+          property="og:title"
+          content={translate({ message: 'home_page.ai_unlimited.title' })}
+        />
+      </Head>
       <HomepageHeader />
       <main className={styles.features}>
         <HomepageFeatures />


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue or feature request that is addressed by this PR. Provide context and motivation for the change. -->
Change the browser title for ai unlimited docs home page to `AI Unlimited Documentation | Teradata Developers Portal`.
Remove possible banner from the ai unlimited docs home page.

### What's included?

<!-- List features included in this PR -->

- Change the title of AI Unlimited docs site to `AI Unlimited Documentation | Teradata Developers Portal`
- Remove possible banner from AI Unlimited docs home page

#### General Tests for Every PR

Please make sure your PR adheres to the following requirements:

- [x] `npm run start` still works.
- [ ] `npm run build` still works.
- [x] Code adheres to project style guidelines (e.g., linting, formatting).
- [x] Any new dependencies have been added to the appropriate files.
- [x] The changes do not introduce new issues or regressions.

### Screenshots or Visual Updates (if applicable)

<!-- If your PR includes changes to the UI or documentation that would benefit from visuals, please include screenshots or relevant images. -->
![ai-unlimited](https://github.com/user-attachments/assets/3878fb15-58b1-49f1-8f7e-86398b97a124)

