### PR TITLE
build(partytown): adjusting where party town script is placed

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "docusaurus start",
     "prestart": "partytown copylib static/~partytown",
     "build": "docusaurus build",
-    "postbuild": "partytown copylib build/~partytown",
+    "prebuild": "partytown copylib static/~partytown",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## Description

Fix for Icons not showing up under different translated sites.

### What's included?

- The partytown script was not being applied for the translated files and only the english main files.

#### General Tests for Every PR

Please make sure your PR adheres to the following requirements:

- [ ] `npm run start` still works.
- [ ] `npm run build` still works.
- [ ] Code adheres to project style guidelines (e.g., linting, formatting).
- [ ] Any new dependencies have been added to the appropriate files.
- [ ] The changes do not introduce new issues or regressions.


