### PR TITLE
Release notes for Teradata MuleSoft Connector (1.0.1 version)

### DIFF
--- a/quickstarts/create-applications/mule-teradata-connector-release-notes.md
+++ b/quickstarts/create-applications/mule-teradata-connector-release-notes.md
@@ -35,6 +35,35 @@ The initial version is based and extended on MuleSoft's [Database Connector - Mu
 | OpenJDK | 8 and 11|
 
 
+## 1.0.1
+Date: April 8, 2025
+
+### What’s New
+- This connector is now compatible with Java 17.
+
+### Features
+The version is based and extended on MuleSoft's [Database Connector - Mule 4](https://docs.mulesoft.com/db-connector/1.14/). This version supports the list of features:
+
+- Perform predefined queries, dynamically constructed queries, and template queries that are self-sufficient and customizable.
+- Use a source listener operation to read from a database in the data source section of a flow.
+- Execute other operations to read and write to a database anywhere in the process section.
+- Run a single bulk update to perform multiple SQL requests.
+- Make Data Definition Language (DDL) requests.
+- Execute stored procedures and SQL scripts.
+- Support pooling profile configuration for database connection
+- Support auto reconnect to database
+
+### Compatibility
+| Software | Version         |
+|----------|-----------------|
+| Mule | 4.3.0 and later |
+| Anypoint Studio | 7.3 and later   |
+| OpenJDK | 8, 11, and 17   |
+
+### Fixed Issues
+- Commons-IO is upgraded to version 2.14.0 to address reported security vulnerabilities.
+
+
 ## See Also
 
 - [MuleSoft Help Center](https://help.mulesoft.com)

--- a/quickstarts/create-applications/mule-teradata-connector-release-notes.md
+++ b/quickstarts/create-applications/mule-teradata-connector-release-notes.md
@@ -36,7 +36,7 @@ The initial version is based and extended on MuleSoft's [Database Connector - Mu
 
 
 ## 1.0.1
-Date: April 8, 2025
+Date: April 22, 2025
 
 ### What’s New
 - This connector is now compatible with Java 17.


### PR DESCRIPTION
Release notes for Teradata MuleSoft Connector (1.0.1 version)

- **What's New:** Added compatibility with Java 17.
- **Compatibility Matrix:** Now includes support for Java 17.
- **Features:** All previous version features are categorized as generic features and are fully supported in the current version.