### PR TITLE
 fix(styles): set columns for better layout

### DIFF
--- a/src/components/DevelopersHomepage/TopPicks.js
+++ b/src/components/DevelopersHomepage/TopPicks.js
@@ -19,7 +19,7 @@ function FeatureStayUpToDate({ img, img2, title, description, href }) {
           <Heading as="h3">{title}</Heading>
         </div>
         
-        {description && <p className={styles.text}>{description}</p>}
+        {description && <p>{description}</p>}
       </div>
     </Link>
   );

--- a/src/components/DevelopersHomepage/TopPicks.js
+++ b/src/components/DevelopersHomepage/TopPicks.js
@@ -19,7 +19,7 @@ function FeatureStayUpToDate({ img, img2, title, description, href }) {
           <Heading as="h3">{title}</Heading>
         </div>
         
-        {description && <p>{description}</p>}
+        {description && <p className={styles.text}>{description}</p>}
       </div>
     </Link>
   );

--- a/src/components/DevelopersHomepage/styles.module.css
+++ b/src/components/DevelopersHomepage/styles.module.css
@@ -350,14 +350,3 @@ a.col {
     max-width: 50%;
   }
 }
-
-@media screen and (min-width: 1025px) {
-  .text{
-    height: 156px;
-  }
-}
-@media screen and (min-width: 1225px) {
-  .text{
-    height: 130px;
-  }
-}

--- a/src/components/DevelopersHomepage/styles.module.css
+++ b/src/components/DevelopersHomepage/styles.module.css
@@ -350,3 +350,14 @@ a.col {
     max-width: 50%;
   }
 }
+
+@media screen and (min-width: 1025px) {
+  .text{
+    height: 156px;
+  }
+}
+@media screen and (min-width: 1225px) {
+  .text{
+    height: 130px;
+  }
+}

--- a/src/components/DevelopersHomepage/styles.module.css
+++ b/src/components/DevelopersHomepage/styles.module.css
@@ -81,7 +81,7 @@ a.col {
   }
 
   .col {
-    --ifm-col-width: 50% !important;
+    --ifm-col-width: 50%;
   }
 
   .col2 {
@@ -133,6 +133,8 @@ a.col {
 
 .pad{
   padding: 16px 0 8px 0;
+  min-width: 180px;
+  max-width: 180px;
 }
 
 .dot{
@@ -340,4 +342,11 @@ a.col {
 .customBullets li::marker {
   color: var(--Primary-Orange, #FF5F02);
   font-size: 13px;
+}
+
+@media screen and (min-width: 996px) and (max-width: 1222px) {
+  .col {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
 }


### PR DESCRIPTION
## Description
When viewing the Dev Portal Homepage on an iPad Pro 13”, Safari, latest OS, the tiles for “Getting started, Documentation, downloads, community” should all be the same width. Since this looks like it may be an issue with the title length of each card, we could switch this to a 2x2 grid at this screen viewport size. Also in the “Top picks from Teradata” section, all the cards should have the same height. 

### What's included?

<!-- List features included in this PR -->

- One
- Two
- Three
#### General Tests for Every PR

Please make sure your PR adheres to the following requirements:

- [ ] `npm run start` still works.
- [ ] `npm run build` still works.
- [ ] Code adheres to project style guidelines (e.g., linting, formatting).
- [ ] Any new dependencies have been added to the appropriate files.
- [ ] The changes do not introduce new issues or regressions.

### Screenshots or Visual Updates (if applicable)


<img width="1105" alt="Screenshot 2025-03-24 at 10 58 08 AM" src="https://github.com/user-attachments/assets/3f5e52e0-964a-4f10-96c1-d8f85ef8d0f2" />

Ipad pro 13
![image](https://github.com/user-attachments/assets/23afd402-0cec-4e90-9cf4-017f8e61d179)
![image](https://github.com/user-attachments/assets/5086b944-a81d-4bbb-9199-8fb55d1c87af)
![image](https://github.com/user-attachments/assets/6e228c79-4acb-4685-84cb-f930c4176bf9)

