### PR TITLE
fix(styles):  the alignment of the icons in the Nav Bar

### DIFF
--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -7,7 +7,7 @@
   margin: 0;
   transition: all var(--ifm-transition-fast)
     var(--ifm-transition-timing-default);
-  height: 30px;
+  height: 24px;
   padding: 0;
 }
 


### PR DESCRIPTION
## Description
Alignment of the icons in the Nav Bar on iPad/Mobile devices. The items in the nav do not seem to be aligned vertically - especially search and the hamburger menu. Effects all iPhone/iPad and Android based devices.


### Screenshots or Visual Updates (if applicable)
**Before**
![image](https://github.com/user-attachments/assets/0ac1381a-25dd-44ea-a8ba-c68878778e07)

**After**
![image](https://github.com/user-attachments/assets/07cf1940-d688-487f-9cb2-9a462c76f164)
